### PR TITLE
fix: 棋盘落子空间未符合五子棋棋盘标准的问题，由13X13改为15X15

### DIFF
--- a/gomoku/src/constants.h
+++ b/gomoku/src/constants.h
@@ -40,11 +40,12 @@ enum BTType {
 
 const int widgetWidth = 1024; //界面宽度
 const int widgetHeight = 768; //界面高度
-
-const int backgrond_margin = 40; //棋盘边距
-const int line_row = 13; //棋盘线长
-const int line_col = 13; //棋盘线宽
-const int chess_size = 44; //棋盘格子宽度
+const int checkerboardSize = 694; //棋盘图片宽高（要求为正方形）
+const int line_num = 15; //棋盘规格15X15
+const int line_row = line_num; //棋盘横线数量
+const int line_col = line_num; //棋盘纵线数量
+const int chess_size = 41; //相邻两线之间的距离
+const int backgrond_margin = (checkerboardSize - chess_size * (line_num - 1)) / 2; //棋盘左、上边距
 const int hover_size = 20;
 
 const int chess_none =  0; //没有棋子

--- a/gomoku/src/widget/checkerboard/checkerboarditem.cpp
+++ b/gomoku/src/widget/checkerboard/checkerboarditem.cpp
@@ -13,11 +13,9 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QDebug>
 
-const int line_num = 13;
-
 CheckerboardItem::CheckerboardItem(QGraphicsItem *parent)
     : QGraphicsItem(parent)
-    , checkerboardPixmap(DHiDPIHelper::loadNxPixmap(":/resources/checkerboard.svg"))
+    , checkerboardPixmap(DHiDPIHelper::loadNxPixmap(":/resources/checkerboard_noline.svg"))
 {
     qCDebug(appLog) << "CheckerboardItem created";
 }
@@ -32,8 +30,8 @@ QRectF CheckerboardItem::boundingRect() const
     //设置棋盘位置和大小
     return QRectF(this->scene()->width() * CheckerboardPosWidth,
                   this->scene()->height() * CheckerboardPosHeight,
-                  662,
-                  662);
+                  checkerboardSize,
+                  checkerboardSize);
 }
 
 void CheckerboardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -50,62 +48,49 @@ void CheckerboardItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *
     painter->save();
     QPen pen;
     QColor penColor("#000000");
-//    penColor.setAlphaF(0.6); // 不带线棋盘透明度
-    penColor.setAlphaF(0.25); //带线棋盘透明度
+    penColor.setAlphaF(0.6); // 不带线棋盘透明度
+    // penColor.setAlphaF(0.25); //带线棋盘透明度
     pen.setColor(penColor);
     painter->setPen(pen);
     for (int i = 0; i < line_num; i++) {
-        //655为实测宽度
         //横线
         int hLineStartX = static_cast<int>(this->scene()->width() * CheckerboardPosWidth //棋盘左边界到整个页面左边界的距离
                                            + backgrond_margin); //线边界到棋盘边界的距离
         int hLineStartY = static_cast<int>(this->scene()->height() * CheckerboardPosHeight //棋盘上边界到整个页面上边界的距离
                                            + backgrond_margin //线边界到棋盘边界的距离
-                                           + chess_size //最上面空了一行, 所以添加一行棋格的宽度
                                            + chess_size * i); //依次递增棋格宽度
-        int hLineEndX = static_cast<int>(this->scene()->width() * CheckerboardPosWidth //棋盘左边界到整个页面左边界的距离
-                                         + 695 //整个棋盘的宽度
-                                         -  backgrond_margin); //线边界到棋盘边界的距离
-        int hLineEndY = static_cast<int>(this->scene()->height() * CheckerboardPosHeight //棋盘上边界到整个页面上边界的距离
-                                         + backgrond_margin //线边界到棋盘边界的距离
-                                         + chess_size //最上面空了一行, 所以添加一行棋格的宽度
-                                         + chess_size * i); //依次递增棋格宽度
+        int hLineEndX = hLineStartX + chess_size * (line_num - 1);; //线边界到棋盘边界的距离
+        int hLineEndY = hLineStartY;
+
         painter->drawLine(hLineStartX, hLineStartY, hLineEndX, hLineEndY);
-        //竖线
+
+        //纵线
         int vLineStartX = static_cast<int>(this->scene()->width() * CheckerboardPosWidth //棋盘左边界到整个页面左边界的距离
                                            + backgrond_margin //线边界到棋盘边界的距离
-                                           + chess_size //最左面空了一行, 所以添加一行棋格的宽度
                                            + chess_size * i); //依次递增棋格宽度
         int vLineStartY = static_cast<int>(this->scene()->height() * CheckerboardPosHeight //棋盘上边界到整个页面上边界的距离
                                            + backgrond_margin); //线边界到棋盘边界的距离
-        int vLineEndX = static_cast<int>(this->scene()->width() * CheckerboardPosWidth //棋盘左边界到整个页面左边界的距离
-                                         + backgrond_margin //线边界到棋盘边界的距离
-                                         + chess_size //最左面空了一行, 所以添加一行棋格的宽度
-                                         + chess_size * i); //依次递增棋格宽度
-        int vLineEndY = static_cast<int>(this->scene()->height() * CheckerboardPosHeight //棋盘上边界到整个页面上边界的距离
-                                         + 695 //整个棋盘的高度
-                                         - backgrond_margin); //线边界到棋盘边界的距离
+        int vLineEndX = vLineStartX;
+        int vLineEndY = vLineStartY + chess_size * (line_num - 1); //线边界到棋盘边界的距离
 
         painter->drawLine(vLineStartX, vLineStartY, vLineEndX, vLineEndY);
+
+        //天元点半径
+        int tianyuanR = 7;
         if (i == line_num / 2) {
             //天元点绘制
             painter->save();
             painter->setPen("#86582E");
             painter->setBrush(QColor("#86582E"));
-            //6为偏移量,调整位置
             int roundX = static_cast<int>(this->scene()->width() * CheckerboardPosWidth
                                           + backgrond_margin
-                                          + chess_size
                                           + chess_size * i
-                                          - 7
-                                          - 0.5); //为保证中心的偏移量
+                                          - tianyuanR); //为保证中心的偏移量
             int roundY = static_cast<int>(this->scene()->height() * CheckerboardPosHeight
                                           + backgrond_margin
-                                          + chess_size
                                           + chess_size * i
-                                          - 7
-                                          - 0.5); //为保证中心的偏移量
-            painter->drawEllipse(roundX, roundY, 14, 14);
+                                          - tianyuanR); //为保证中心的偏移量
+            painter->drawEllipse(roundX, roundY, tianyuanR*2, tianyuanR*2);
             painter->restore();
         }
     }

--- a/gomoku/src/widget/checkerboard/checkerboardscene.cpp
+++ b/gomoku/src/widget/checkerboard/checkerboardscene.cpp
@@ -117,10 +117,9 @@ void CheckerboardScene::initChess()
             connect(buttonStartPause, &BTStartPause::signalGameStop, chess, &ChessItem::slotGameStop);//暂停游戏
             connect(this, &CheckerboardScene::signalGameContinue, chess, &ChessItem::slotGameContinue);//继续游戏
             connect(chess, &ChessItem::signalCPaintItem, this, &CheckerboardScene::slotCPaintItem);//落子坐标,判断输赢
-            //整个棋盘左上角点,加上偏移量到达绘制区域,减去棋格半径是以棋子所在rect左上角为圆点绘制棋子
             //循环添加每个位置棋子
-            chess->setPos(this->width() * lefttopChessPosWidth + chessOffset  - chess_size / 2 + chess_size * j,
-                          this->height() * lefttopChessPosHeight + chessOffset  - chess_size / 2 + chess_size * i);
+            chess->setPos(this->width() * lefttopChessPosWidth + backgrond_margin + chess_size * j,
+                          this->height() * lefttopChessPosHeight + backgrond_margin + chess_size * i);
             pieceItems.append(chess);
             addItem(chess);
             chessHasPaint[i][j] = false;

--- a/gomoku/src/widget/checkerboard/checkerboardscene.h
+++ b/gomoku/src/widget/checkerboard/checkerboardscene.h
@@ -83,7 +83,7 @@ private:
     QSound *playChessSound = nullptr;
 #endif
     QVector<QVector<ChessItem *>> chessItemList{}; //棋子数组
-    bool chessHasPaint[13][13] = {{false}}; //棋子坐标数组,保存每个位置是否绘制棋子
+    bool chessHasPaint[line_row][line_col] = {{false}}; //棋子坐标数组,保存每个位置是否绘制棋子
     CheckerboardItem *cbitem = nullptr; //棋盘item
     BTStartPause *buttonStartPause = nullptr; //开始、暂停按钮
     BTReplay *buttonReplay = nullptr; //重玩按钮
@@ -107,7 +107,6 @@ private:
     //以下位置参数,根据UI图得来
     const qreal lefttopChessPosWidth = 0.02; //左上角第一个棋子位置占整个scene宽度比例
     const qreal lefttopChessPosHeight = 0.007; //左上角第一个棋子位置占整个scene高度比例
-    const int chessOffset = 83; //棋子位置偏移量
 };
 
 #endif // CHECKERBOARDSCENE_H

--- a/gomoku/src/widget/chess/chessitem.cpp
+++ b/gomoku/src/widget/chess/chessitem.cpp
@@ -113,9 +113,8 @@ void ChessItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
             painter->setBrush(backColor);
 
             //绘制hover外层的阴影效果
-            //10为圆点所在的rect左上角坐标,24为圆点半径
-            //此坐标根据棋子要显示的位置得来
-            painter->drawEllipse(QRect(10, 10, 24, 24));
+            int outerR = 12;
+            painter->drawEllipse(QRect(-outerR, -outerR, outerR*2, outerR*2));
             painter->restore();
 
             //绘制白点或黑点
@@ -128,10 +127,10 @@ void ChessItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                 chessColor.setAlphaF(0.7);
             }
             painter->setBrush(chessColor);
+
             //绘制hover状态
-            //17为圆点所在的rect左上角坐标,10为圆点半径
-            //此坐标根据棋子要显示的位置得来
-            painter->drawEllipse(QRect(17, 17, 10, 10));
+            int innerR = 5;
+            painter->drawEllipse(QRect(-innerR, -innerR, innerR*2, innerR*2));
             painter->restore();
         }
     }
@@ -139,8 +138,8 @@ void ChessItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 
 QRectF ChessItem::boundingRect() const
 {
-    //棋子大小
-    return QRectF(0, 0, chess_size, chess_size);
+    int chessR = 22;
+    return QRectF(-chessR, -chessR, chessR*2, chessR*2);
 }
 
 void ChessItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event)


### PR DESCRIPTION
在棋盘（图片素材）大小不变的情况下，酌情调整棋盘中线与线的间距，
以便容纳15条横线与15条纵线组成的落子空间，
并且确保最外侧边线上的落子不超出边框范围。

Issue: https://bbs.deepin.org/post/269951