### PR TITLE
fix: update lrelease executable search paths for Qt5/Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,12 @@ file (GLOB DTNG_TS_FILES translations/*.ts)
 
 #lrelease start
 #发布qm文件
-find_program(LRELEASE_EXECUTABLE lrelease)
+find_program(LRELEASE_EXECUTABLE lrelease PATHS "/usr/lib/qt6/bin" "/usr/lib/qt5/bin" NO_DEFAULT_PATH)
+if(NOT LRELEASE_EXECUTABLE)
+    find_program(LRELEASE_EXECUTABLE lrelease)
+endif()
 foreach(_ts_file ${DTNG_TS_FILES})
-        execute_process(COMMAND ${LRELEASE_EXECUTABLE}   ${_ts_file})
+        execute_process(COMMAND ${LRELEASE_EXECUTABLE} ${_ts_file})
 endforeach()
 #lrelease end
 


### PR DESCRIPTION
Add specific search paths for lrelease in Qt5 and Qt6 directories before falling back to default system path.

Log: update lrelease executable search paths for Qt5/Qt6